### PR TITLE
Make notice dismissable

### DIFF
--- a/views/mixins/form.jade
+++ b/views/mixins/form.jade
@@ -94,7 +94,7 @@ mixin warning()
 mixin notice()
   -var notice = locals.notice;
   - if (typeof(notice) != 'undefined')
-    .alert.alert-block.alert-info !{notice}
+    .alert.alert-block.alert-info.alert-dismissible !{notice}
 
 mixin dialogBox(h)
   .modal-dialog


### PR DESCRIPTION
It bothered me that I couldn't dismiss the "The page has been updated. Edit it again?" message.
